### PR TITLE
IntelliJ ignoring .iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /tmp
 
 /.idea
+fcr.iml
 
 /config/database.yml
 config/email_settings.yml


### PR DESCRIPTION
Here we add a pattern to ignore: fcr.iml file